### PR TITLE
fix: include password in login type

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,7 +7,7 @@ interface AuthContextType {
   user: User | null
   chatConfig: ChatConfig | null
   isLoading: boolean
-  login: (username: string) => Promise<{ success: boolean; error?: string }>
+  login: (username: string, password: string) => Promise<{ success: boolean; error?: string }>
   loginWithAccessCode: (username: string, accessCode: string) => Promise<{ success: boolean; error?: string }>
   register: (data: RegisterData) => Promise<{ success: boolean; error?: string }>
   logout: () => void


### PR DESCRIPTION
## Summary
- update `AuthContext` login signature to require password

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 'role' is assigned a value but never used and more)*
- `npm run build` *(warns: Attempted import error: '@/lib/prisma' does not contain a default export)*

------
https://chatgpt.com/codex/tasks/task_b_68adaf7bce708327978132c213faa3d6